### PR TITLE
A few critical fixes

### DIFF
--- a/include/LBFGS.h
+++ b/include/LBFGS.h
@@ -19,7 +19,7 @@ namespace LBFGSpp {
 /// L-BFGS solver for unconstrained numerical optimization
 ///
 template < typename Scalar,
-           template<class> class LineSearch = LineSearchBacktracking >
+           template<class> class LineSearch = LineSearchNocedalWright >
 class LBFGSSolver
 {
 private:

--- a/include/LBFGSpp/LineSearchMoreThuente.h
+++ b/include/LBFGSpp/LineSearchMoreThuente.h
@@ -247,7 +247,7 @@ public:
 
                 // std::cout << "Case 1: new step = " << new_step;
 
-            } else if(gt * (fI_lo - step) > Scalar(0)) {
+            } else if(gt * (I_lo - step) > Scalar(0)) {
                 // Case 2: ft <= fl, gt * (al - at) > 0
                 new_step = std::min(step_max, step + delta * (step - I_lo));
 

--- a/include/LBFGSpp/Param.h
+++ b/include/LBFGSpp/Param.h
@@ -127,7 +127,7 @@ public:
     ///
     /// The line search termination condition.
     /// This parameter specifies the line search termination condition that will be used
-    /// by the LBFGS routine. The default value is `LBFGS_LINESEARCH_BACKTRACKING_ARMIJO`.
+    /// by the LBFGS routine. The default value is `LBFGS_LINESEARCH_BACKTRACKING_STRONG_WOLFE`.
     ///
     int    linesearch;
     ///
@@ -176,7 +176,7 @@ public:
         past           = 0;
         delta          = Scalar(0);
         max_iterations = 0;
-        linesearch     = LBFGS_LINESEARCH_BACKTRACKING_ARMIJO;
+        linesearch     = LBFGS_LINESEARCH_BACKTRACKING_STRONG_WOLFE;
         max_linesearch = 20;
         min_step       = Scalar(1e-20);
         max_step       = Scalar(1e+20);

--- a/include/LBFGSpp/SubspaceMin.h
+++ b/include/LBFGSpp/SubspaceMin.h
@@ -250,17 +250,17 @@ public:
             {
                 Vector res;
                 bfgs.apply_PtWMv(L_set, Fy, res, Scalar(-1));
-                res.noalias() += subvec(vecc, yL_set);
+                res.noalias() += subvec(vecc, yL_set) + bfgs.theta() * subvec(vecy, yL_set);
                 subvec_assign(lambda, yL_set, res);
             }
 
             // Solve mu[U] = -B[U, F] * y - c[U]
             if(nU > 0)
             {
-                Vector res;
-                bfgs.apply_PtWMv(U_set, Fy, res, Scalar(-1));
-                res.noalias() = -res - subvec(vecc, yU_set);
-                subvec_assign(mu, yU_set, res);
+                Vector negRes;
+                bfgs.apply_PtWMv(U_set, Fy, negRes, Scalar(-1));
+                negRes.noalias() += subvec(vecc, yU_set) + bfgs.theta() * subvec(vecy, yU_set);
+                subvec_assign(mu, yU_set, -negRes);
             }
 
             // Test convergence


### PR DESCRIPTION
The first commit fixes a typo in the Moré-Thuente line search. Before the fix, a function value at a coordinate was supplied where the coordinate itself was expected. Arbitrarily strange things could happen. Resolves #9.
The second commit changes the default LBFGS line search to Nocedal-Wright. Opposed to the previous default (Armijo-only backtracking), this line search enforces the strong Wolfe conditions, extending the range of validity of LBFGS to non-convex functions. It seems reasonable that LBFGSpp should support non-convex functions out of the box. Resolves #21.
The third commit fixes a critical omission in the subspace minimization code. When updating the `lambda` and `mu` vectors, a multiplication with the BFGS matrix is needed, preceded by a projection onto the free variables (index set F) and followed by a projection onto the L and U index sets, respectively. Before the fix, the theta-times-identity-matrix term of the BFGS matrix was omitted from the multiplication. This would have been permissible if L/U and F were mutually exclusive, but they are not. It may seem like L/U pertain to active variables, which are exclusive with F by definition, since they are pinned to the lower/upper boundaries, but they started out as free variables. The fix adds the theta terms. Resolves #15.
I've mentioned some of these issues previously in #23. I think the ideas in there are still relevant, but I wouldn't call them an issue anymore, so I think that can get resolved too.