### PR TITLE
support building with Eigen3 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(lbfgspp INTERFACE
 # | FIND EXTERNAL LIBRARIES |
 # + ----------------------- +
 
-find_package(Eigen3 3.0 REQUIRED)
+find_package(Eigen3 REQUIRED)
 target_link_libraries(lbfgspp INTERFACE Eigen3::Eigen)
 message("-- Eigen3 version: " ${EIGEN3_VERSION_STRING})
 

--- a/examples/example-rosenbrock-bracketing.cpp
+++ b/examples/example-rosenbrock-bracketing.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <Eigen/Core>
 #include <iostream>
 #include <LBFGS.h>

--- a/examples/example-rosenbrock-comparison.cpp
+++ b/examples/example-rosenbrock-comparison.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <Eigen/Core>
 #include <iostream>
 #include <LBFGS.h>

--- a/include/LBFGSpp/LineSearchBracketing.h
+++ b/include/LBFGSpp/LineSearchBracketing.h
@@ -5,6 +5,7 @@
 #ifndef LBFGSPP_LINE_SEARCH_BRACKETING_H
 #define LBFGSPP_LINE_SEARCH_BRACKETING_H
 
+#include <cassert>
 #include <Eigen/Core>
 #include <stdexcept>  // std::runtime_error
 #include "Param.h"


### PR DESCRIPTION
Due to version scheme change (https://gitlab.com/libeigen/eigen/-/releases#versioning), Eigen3 5.0.0 can not be found with prior find_package.

Given the version check is the minimum version (3.0), removing it seems to be simplest way to handle all Eigen3 releases until there is a known incompatibility.

The alternative is to use 2 lookups (first via range as mentioned in https://libeigen.gitlab.io/eigen/docs-5.0/TopicCMakeGuide.html and fall back for older versions), e.g.
```cmake
find_package(Eigen3 3...5 QUIET)
if(NOT Eigen3_FOUND)
  find_package(Eigen3 3.0 REQUIRED)
endif()
```

Above will need to be updated every time new major release is available, i.e. `3...6`, `3...7`, etc.

---

Explicit `cassert` headers are also needed after newer Eigen.